### PR TITLE
Removed use of deprecated function in pillow

### DIFF
--- a/hvzsite/hvz/models.py
+++ b/hvzsite/hvz/models.py
@@ -69,7 +69,7 @@ def resize_image(photo, width, height, format="JPEG"):
     output = BytesIO()
     im = im.convert('RGB')
     #Resize/modify the image
-    im.thumbnail( (width,height) , Image.ANTIALIAS )
+    im.thumbnail( (width,height) , Image.Resampling.LANCZOS )
     #after modifications, save it to the output
     im.save(output, format=format, quality=95)
     output.seek(0)

--- a/hvzsite/hvz/views_api_admin.py
+++ b/hvzsite/hvz/views_api_admin.py
@@ -241,7 +241,7 @@ class AdminAPIViews(object):
             img = Image.open(im_file)   # img is now PIL Image object
             output = BytesIO()
             im = img.convert('RGB')
-            im.thumbnail( (400, 400) , Image.ANTIALIAS )
+            im.thumbnail( (400, 400) , Image.Resampling.LANCZOS )
             im.save(output, format="JPEG", quality=95)
             output.seek(0)
             requested_player.picture = InMemoryUploadedFile(output,'ImageField', "%s.jpg" % requested_player.player_uuid, 'image/jpeg', sys.getsizeof(output), None)


### PR DESCRIPTION
Use on versions of pillow >= 10.0.0 causes an error when attempting to upload an image, as ANTIALIAS was renamed and moved. This just uses the new name and location, PIL.Image.Resampling.LANCZOS. 

Info: https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants