### PR TITLE
Fixed issue with new django versions not accepting get requests to logout

### DIFF
--- a/hvzsite/templates/base.html
+++ b/hvzsite/templates/base.html
@@ -257,7 +257,11 @@ $(document).ready(function () {
                 <ul class="navbar-nav ms-auto">
                   <li class="nav-item">
                     {% if user.is_authenticated %}
-                    <a class="nav-link" href="/me/">{{user.first_name}} {{user.last_name}}</a> </li><li class="nav-item"><a class="nav-link logout-link" href="/accounts/logout/">Logout</a>
+                    <a class="nav-link" href="/me/">{{user.first_name}} {{user.last_name}}</a> </li><li class="nav-item">
+                    <form method="post" action="{% url 'logout' %}">
+                        {% csrf_token %}
+                        <button class="nav-link logout-link" type="submit">Logout</button>
+                    </form>
                     {% else %}
                     <a class="nav-link" href="/accounts/login/">Login / Register</a>
                     {% endif %}

--- a/hvzsite/templates/base.html
+++ b/hvzsite/templates/base.html
@@ -257,7 +257,8 @@ $(document).ready(function () {
                 <ul class="navbar-nav ms-auto">
                   <li class="nav-item">
                     {% if user.is_authenticated %}
-                    <a class="nav-link" href="/me/">{{user.first_name}} {{user.last_name}}</a> </li><li class="nav-item">
+                    <a class="nav-link" href="/me/">{{user.first_name}} {{user.last_name}}</a> </li>
+                    <li class="nav-item">
                     <form method="post" action="{% url 'logout' %}">
                         {% csrf_token %}
                         <button class="nav-link logout-link" type="submit">Logout</button>


### PR DESCRIPTION
After Django version 4.1, you are unable to logout via get requests (when using the default setup) for security reasons, switched to using post requests via an html form. 